### PR TITLE
Fix tests

### DIFF
--- a/test/json.rb
+++ b/test/json.rb
@@ -1,56 +1,56 @@
 assert('parse object') do
-  JSON::parse('{"foo": "bar"}') == {"foo"=>"bar"}
+  assert_equal({"foo"=>"bar"}, JSON::parse('{"foo": "bar"}'))
 end
 assert('parse null') do
-  JSON::parse('{"foo": null}') == {"foo"=>nil}
+  assert_equal({"foo"=>nil}, JSON::parse('{"foo": null}'))
 end
 assert('parse array') do
-  JSON::parse('[true, "foo"]')[1] == "foo"
+  assert_equal "foo", JSON::parse('[true, "foo"]')[1] 
 end
 assert('parse multi-byte') do
-  assert_equal(JSON::parse('{"あいうえお": "かきくけこ"}'), {"あいうえお"=>"かきくけこ"})
+  assert_equal({"あいうえお"=>"かきくけこ"}, JSON::parse('{"あいうえお": "かきくけこ"}'))
 end
 assert('stringify boolean') do
-  JSON::stringify(true) == "true"
+  assert_equal "true", JSON::stringify(true)
 end
 assert('stringify symbol') do
-  JSON::stringify(:symbol) == "\"symbol\""
+  assert_equal "\"symbol\"", JSON::stringify(:symbol)
 end
 assert('strnigify object with numeric value') do
-  JSON::stringify({"foo"=>"bar"}) == '{"foo":"bar"}'
+  assert_equal '{"foo":"bar"}', JSON::stringify({"foo"=>"bar"})
 end
 assert('strnigify object with string value') do
-  JSON::stringify({"foo"=> 1}) == '{"foo":1}'
+  assert_equal '{"foo":1}', JSON::stringify({"foo"=> 1})
 end
 assert('stringify object with float value') do
-  JSON::stringify({"foo"=> 2.5}) == '{"foo":2.5}'
+  assert_equal '{"foo":2.5}', JSON::stringify({"foo"=> 2.5})
 end
 assert('stringify object with nil value') do
-  JSON::stringify({"foo"=> nil}) == '{"foo":null}'
+  assert_equal '{"foo":null}', JSON::stringify({"foo"=> nil})
 end
 assert('stringify object with boolean key and float value') do
-  JSON::stringify({true=> 5.0}) == '{"true":5}'
+  assert_equal '{"true":5}', JSON::stringify({true=> 5.0})
 end
 assert('stringify object with object key and float value') do
-  JSON::stringify({{"foo"=> "bar"}=> 1.5}) == '{"{\"foo\"=>\"bar\"}":1.5}'
+  assert_equal '{"{\"foo\"=>\"bar\"}":1.5}', JSON::stringify({{"foo"=> "bar"}=> 1.5})
 end
 assert('stringify empty array') do
-  JSON::stringify([]) == "[]"
+  assert_equal "[]",  JSON::stringify([])
 end
 assert('strnigify array with few elements') do
-  JSON::stringify([1,true,"foo"]) == "[1,true,\"foo\"]"
+  assert_equal "[1,true,\"foo\"]", JSON::stringify([1,true,"foo"]) 
 end
 assert('stringify object with several keys') do
-  JSON::stringify({"bar"=> 2, "foo"=>1}) == '{"bar":2,"foo":1}'
+  assert_equal '{"bar":2,"foo":1}', JSON::stringify({"bar"=> 2, "foo"=>1})
 end
 assert('stringify multi-byte') do
-  JSON::stringify({"foo"=>"ふー", "bar"=> "ばー"}) == '{"foo":"ふー","bar":"ばー"}'
+  assert_equal '{"foo":"ふー","bar":"ばー"}', JSON::stringify({"foo"=>"ふー", "bar"=> "ばー"})
 end
 assert('stringify escaped') do
-  JSON::stringify(['\\']) == '["\\\\"]'
+  assert_equal '["\\\\"]', JSON::stringify(['\\'])
 end
 assert('stringify escaped quote') do
-  JSON::stringify(['\\\"']) == '["\\\\\\\\\""]'
+  assert_equal '["\\\\\\\\\""]', JSON::stringify(['\\\"'])
   s = JSON::stringify(['\\\"'])
   assert_equal '[', s[0]
   assert_equal '"', s[1]


### PR DESCRIPTION
If assert_xxx is used in test, we see Expected and Actual value.

Test:

```ruby
assert('stringify boolean') do
  assert_equal "true1", JSON::stringify(true)
end
```

Result:

```
Fail: stringify boolean (mrbgems: mruby-json)
 - Assertion[1] Failed: Expected to be equal
    Expected: "true1"
      Actual: "true"
```