### PR TITLE
Explicitly iterate list of methods in mrb_method_defined

### DIFF
--- a/src/mrb_json.c
+++ b/src/mrb_json.c
@@ -27,9 +27,18 @@ mrb_method_defined(mrb_state* mrb, mrb_value value, const char* name) {
   int ai = mrb_gc_arena_save(mrb);
   mrb_sym mid = mrb_intern_cstr(mrb, name);
   mrb_value methods = mrb_funcall(mrb, value, "public_methods", 1, mrb_false_value());
-  mrb_value included = mrb_funcall(mrb, methods, "include?", 1, mrb_symbol_value(mid), NULL);
+  mrb_bool included = FALSE;
+  if (mrb_array_p(methods)) {
+    mrb_int i;
+    for (i = 0; i < RARRAY_LEN(methods); ++i) {
+        if (mid == mrb_symbol(RARRAY_PTR(methods)[i])) {
+            included = TRUE;
+            break;
+        }
+    }
+  }
   mrb_gc_arena_restore(mrb, ai);
-  return mrb_type(included) == MRB_TT_TRUE;
+  return included;
 }
 
 static mrb_value


### PR DESCRIPTION
Current implementation generates exception:

    [3] mruby/mrblib/enum.rb:166:in include?
    [4] mruby/mrblib/array.rb:17:in each
    mruby/mrblib/array.rb:17:unexpected return (LocalJumpError)