### PR TITLE
fix runtime exception by adding mruby-metaprog as a depencency

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,4 +2,5 @@ MRuby::Gem::Specification.new('mruby-json') do |spec|
   spec.license = 'MIT'
   spec.authors = 'mattn'
   spec.cc.defines << 'JSON_FIXED_NUMBER'
+  spec.add_dependency 'mruby-metaprog', :core => 'mruby-metaprog'
 end


### PR DESCRIPTION
Right now `public_methods` is moved into mruby-metaprog core mrbgem. This should be able to fix test when building from current mruby master