### PR TITLE
Fix compatibility with stable mruby

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,6 +1,8 @@
+require "#{MRUBY_ROOT}/lib/mruby/source"
+
 MRuby::Gem::Specification.new('mruby-json') do |spec|
   spec.license = 'MIT'
   spec.authors = 'mattn'
   spec.cc.defines << 'JSON_FIXED_NUMBER'
-  spec.add_dependency 'mruby-metaprog', :core => 'mruby-metaprog' if Dir.exist? "#{MRUBY_ROOT}/mrbgems/mruby-metaprog"
+  spec.add_dependency 'mruby-metaprog', :core => 'mruby-metaprog' if MRuby::Source::MRUBY_VERSION >= '2.0.0'
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,5 +2,5 @@ MRuby::Gem::Specification.new('mruby-json') do |spec|
   spec.license = 'MIT'
   spec.authors = 'mattn'
   spec.cc.defines << 'JSON_FIXED_NUMBER'
-  spec.add_dependency 'mruby-metaprog', :core => 'mruby-metaprog'
+  spec.add_dependency 'mruby-metaprog', :core => 'mruby-metaprog' if Dir.exist? "#{MRUBY_ROOT}/mrbgems/mruby-metaprog"
 end


### PR DESCRIPTION
`mruby-metaprog` is only available for mruby-head and not required for mruby-1.4.1 or below.