### PR TITLE
fixed tests for mruby version 1.3.0

### DIFF
--- a/test/json.rb
+++ b/test/json.rb
@@ -5,7 +5,7 @@ assert('parse null') do
   assert_equal({"foo"=>nil}, JSON.parse('{"foo": null}'))
 end
 assert('parse array') do
-  assert_equal "foo", JSON.parse('[true, "foo"]')[1] 
+  assert_equal "foo", JSON.parse('[true, "foo"]')[1]
 end
 assert('parse multi-byte') do
   assert_equal({"あいうえお"=>"かきくけこ"}, JSON.parse('{"あいうえお": "かきくけこ"}'))
@@ -41,7 +41,7 @@ assert('stringify empty array') do
   assert_equal "[]",  JSON.stringify([])
 end
 assert('strnigify array with few elements') do
-  assert_equal "[1,true,\"foo\"]", JSON.stringify([1,true,"foo"]) 
+  assert_equal "[1,true,\"foo\"]", JSON.stringify([1,true,"foo"])
 end
 assert('stringify object with several keys') do
   assert_equal '{"bar":2,"foo":1}', JSON.stringify({"bar"=> 2, "foo"=>1})
@@ -148,6 +148,6 @@ assert('load') do
   assert_equal({"foo"=>"bar"}, o)
 
   o = nil
-  assert_raise(JSON::ParserError) { JSON.load '{' {|x| o = x} }
+  assert_raise(JSON::ParserError) { JSON.load('{') {|x| o = x} }
   assert_equal(nil, o)
 end


### PR DESCRIPTION
tests failed in mruby version 1.3.0

```
CC    build/host/mrbgems/mruby-test/mrbtest.c -> build/host/mrbgems/mruby-test/mrbtest.o
      MRBC ../test/json.rb 
/Users/accaman/repos/mruby-json/test/json.rb:151:49: syntax error, unexpected '{', expecting '}'
/Users/accaman/repos/mruby-json/test/json.rb:151:61: syntax error, unexpected '}', expecting keyword_end
rake aborted!
exit
```