### PR TITLE
[FIXED TEST] `Float#to_s` CRuby compatible in mruby 2.0.1

### DIFF
--- a/test/json.rb
+++ b/test/json.rb
@@ -32,7 +32,7 @@ assert('stringify object with nil value') do
   assert_equal '{"foo":null}', JSON.stringify({"foo"=> nil})
 end
 assert('stringify object with boolean key and float value') do
-  assert_equal '{"true":5}', JSON.stringify({true=> 5.0})
+  assert_equal '{"true":5.0}', JSON.stringify({true=> 5.0})
 end
 assert('stringify object with object key and float value') do
   assert_equal '{"{\"foo\"=>\"bar\"}":1.5}', JSON.stringify({{"foo"=> "bar"}=> 1.5})


### PR DESCRIPTION
Hi @mattn

A test was failing because `Float#to_s` CRuby compatible in mruby 2.0.1.

https://github.com/mruby/mruby/commit/9f081183d2351195c821fbe1520975ba000cafb5

Test failure with mruby-json:

```
Fail: stringify object with boolean key and float value (mrbgems: mruby-json)
 - Assertion[1]
    Expected: "{\"true\":5}"
      Actual: "{\"true\":5.0}"
  Total: 715
     OK: 714
     KO: 1
  Crash: 0
Warning: 0
   Skip: 0
```

I fixed it.