### PR TITLE
mruby-2.0.1 `Float#to_s` add a trailing `.0`, so mruby-json keep compatibility

### DIFF
--- a/src/mrb_json.c
+++ b/src/mrb_json.c
@@ -3,6 +3,7 @@
 #include <mruby/array.h>
 #include <mruby/hash.h>
 #include <mruby/variable.h>
+#include <mruby/numeric.h>
 #include <stdio.h>
 #include <math.h>
 #include "parson.h"
@@ -27,6 +28,7 @@
 #endif
 
 #define E_PARSER_ERROR mrb_class_get_under(mrb, mrb_module_get(mrb, "JSON"), "ParserError")
+#define MRB_FLO_TO_STR_FMT "%.16g"
 
 /*********************************************************
  * main
@@ -68,14 +70,16 @@ mrb_value_to_string(mrb_state* mrb, mrb_value value, int pretty) {
 
   switch (mrb_type(value)) {
   case MRB_TT_FIXNUM:
-#ifndef MRB_WITHOUT_FLOAT
-  case MRB_TT_FLOAT:
-#endif
   case MRB_TT_TRUE:
   case MRB_TT_FALSE:
   case MRB_TT_UNDEF:
     str = mrb_funcall(mrb, value, "to_s", 0, NULL);
     break;
+#ifndef MRB_WITHOUT_FLOAT
+  case MRB_TT_FLOAT:
+    str = mrb_float_to_str(mrb, value, MRB_FLO_TO_STR_FMT);
+    break;
+#endif
   case MRB_TT_SYMBOL:
     value = mrb_funcall(mrb, value, "to_s", 0, NULL);
     /* FALLTHROUGH */


### PR DESCRIPTION
Hi @mattn @take-cheeze

A test was failing because `Float#to_s` CRuby compatible in mruby 2.0.1.

https://github.com/mruby/mruby/commit/9f081183d2351195c821fbe1520975ba000cafb5

Test failure with mruby-json:

```
Fail: stringify object with boolean key and float value (mrbgems: mruby-json)
 - Assertion[1]
    Expected: "{\"true\":5}"
      Actual: "{\"true\":5.0}"
  Total: 715
     OK: 714
     KO: 1
  Crash: 0
Warning: 0
   Skip: 0
```

The following Pull-Req has been modified to follow the mruby-2.0.1 specification.

ref: https://github.com/mattn/mruby-json/pull/40

However, there is the following remark of @take-cheeze .

> Sometimes mruby promotes overflowed integer to float so I feel {"true":5} should be kept.

I agreed and kept the old mruby `Float#to_s` specification.
