### PR TITLE
Protect strings from GC in `JSON.generate`

### DIFF
--- a/src/mrb_json.c
+++ b/src/mrb_json.c
@@ -81,7 +81,6 @@ mrb_value_to_string(mrb_state* mrb, mrb_value value, int pretty) {
     /* FALLTHROUGH */
   case MRB_TT_STRING:
     {
-      int ai = mrb_gc_arena_save(mrb);
       char* ptr = RSTRING_PTR(value);
       char* end = RSTRING_END(value);
       str = mrb_str_new_cstr(mrb, "\""); 
@@ -115,7 +114,6 @@ mrb_value_to_string(mrb_state* mrb, mrb_value value, int pretty) {
         ptr++;
       }
       mrb_str_cat_cstr(mrb, str, "\""); 
-      mrb_gc_arena_restore(mrb, ai);
     }
     break;
   case MRB_TT_HASH:


### PR DESCRIPTION
String objects could be GC'd if `mrb_value_to_string()` was recursively called by an array or hash object.
This patch no longer handles GC arena indices, since no other objects are created when strings are dumped.
